### PR TITLE
Enable WordPress multisite mode

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,8 +8,12 @@ RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /oxygen/
 RewriteRule ^index\.php$ - [L]
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,NC,L]
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
 RewriteRule . /oxygen/index.php [L]
 </IfModule>
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -86,6 +86,15 @@ define('WP_DEBUG_DISPLAY', false);
 
 /* Add any custom values between this line and the "stop editing" line. */
 
+// Enable WordPress Multisite configuration
+define( 'WP_ALLOW_MULTISITE', true );
+define( 'MULTISITE', true );
+define( 'SUBDOMAIN_INSTALL', false );
+define( 'DOMAIN_CURRENT_SITE', 'localhost' );
+define( 'PATH_CURRENT_SITE', '/oxygen/' );
+define( 'SITE_ID_CURRENT_SITE', 1 );
+define( 'BLOG_ID_CURRENT_SITE', 1 );
+
 
 
 /* That's all, stop editing! Happy publishing. */


### PR DESCRIPTION
## Summary
- enable multisite constants in `wp-config.php`
- update `.htaccess` rules for a subdirectory-based network

## Testing
- `php -l wp-config.php`
- `php -l .htaccess`

------
https://chatgpt.com/codex/tasks/task_e_6843157f05d08324b46957fadd4d76c3